### PR TITLE
support for files with different delimiters

### DIFF
--- a/scripts/clean_tweets.py
+++ b/scripts/clean_tweets.py
@@ -5,10 +5,18 @@ def parse_arguments():
     parser = argparse.ArgumentParser()
     parser.add_argument('-i', required=True, help='input tweets tsv file')
     parser.add_argument('-o', required=False, default='test_tweets_cleaned.tsv', help='output file')
+    parser.add_argument('-d', required=False, default='\t', help='the file delimiter')
     return parser.parse_args()
 
 def main(**kwargs):
-    df = pd.read_csv(kwargs.get('i'), delimiter='\t')
+    sep = kwargs.get('delimiter')
+    df = pd.read_csv(kwargs.get('i'), delimiter=sep)
+    print(df)
+    df = df[df['keep'].astype(int)==1]
+
+    if len(df) != 1000:
+        print(f'Dataset does not have 1000 rows, got input of {len(df)} rows')
+        return
 
     # remove links, lowercase all tokens, remove punctuation and emojis
     df['text'] = (df['text']
@@ -20,9 +28,9 @@ def main(**kwargs):
 
     df['topics'] = df['topics'].apply(lambda s: str(s).strip())
 
-    df.to_csv(kwargs.get('o'), sep='\t', index=False)
+    df.to_csv(kwargs.get('o'), sep=sep, index=False)
 
 
 if __name__ == "__main__":
     args = parse_arguments()
-    main(i=args.i, o=args.o)
+    main(i=args.i, o=args.o, delimiter=args.d)

--- a/src/tweet_statistics.py
+++ b/src/tweet_statistics.py
@@ -7,14 +7,15 @@ def parse_arguments():
     parser = argparse.ArgumentParser()
     parser.add_argument('-i', required=True, help='input tweets tsv file')
     parser.add_argument('-o', required=False, help='output file')
+    parser.add_argument('-d', required=False, default='\t', help='the file delimiter')
     return parser.parse_args()
 
 def count_rows_by_key(df: pd.DataFrame, k: str, col1: str, col2: str) -> dict:
     return json.loads(df[df[col1]==k][col2].value_counts().to_json())
 
 def main(**kwargs):
-    df = pd.read_csv(kwargs.get('i'), delimiter='\t')
-
+    df = pd.read_csv(kwargs.get('i'), delimiter=kwargs.get('delimiter'))
+    
     results = {'overall': {}, 'by_topic': {}, 'by_sentiment': {}, 'mean_text_length': -1}
     
     results['overall']['topics'] = json.loads(df['topics'].value_counts().to_json())
@@ -40,4 +41,4 @@ def main(**kwargs):
 
 if __name__ == "__main__":
     args = parse_arguments()
-    main(i=args.i, o=args.o)
+    main(i=args.i, o=args.o, delimiter=args.d)


### PR DESCRIPTION
When reading in the data as a tsv file, pandas misses 3 rows for some reason. It works with csv files though, so I just added this fix for now.